### PR TITLE
Support Quota metrics

### DIFF
--- a/internal/entrypoint/run.go
+++ b/internal/entrypoint/run.go
@@ -137,7 +137,7 @@ func Run(ctx context.Context, config *Config, exporter otlexporters.Otlexporter,
 				logger.Info("powerscale quota capacity metrics collection is disabled")
 				continue
 			}
-			powerScaleSvc.ExportVolumeMetrics(ctx)
+			powerScaleSvc.ExportQuotaMetrics(ctx)
 		case err := <-errCh:
 			if err == nil {
 				continue

--- a/internal/entrypoint/run_test.go
+++ b/internal/entrypoint/run_test.go
@@ -45,7 +45,7 @@ func Test_Run(t *testing.T) {
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := mocks.NewMockService(ctrl)
-			svc.EXPECT().ExportVolumeMetrics(gomock.Any()).AnyTimes()
+			svc.EXPECT().ExportQuotaMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterCapacityMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterPerformanceMetrics(gomock.Any()).AnyTimes()
 
@@ -131,7 +131,7 @@ func Test_Run(t *testing.T) {
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := mocks.NewMockService(ctrl)
-			svc.EXPECT().ExportVolumeMetrics(gomock.Any()).AnyTimes()
+			svc.EXPECT().ExportQuotaMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterCapacityMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterPerformanceMetrics(gomock.Any()).AnyTimes()
 
@@ -160,7 +160,7 @@ func Test_Run(t *testing.T) {
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := mocks.NewMockService(ctrl)
-			svc.EXPECT().ExportVolumeMetrics(gomock.Any()).AnyTimes()
+			svc.EXPECT().ExportQuotaMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterCapacityMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterPerformanceMetrics(gomock.Any()).AnyTimes()
 			return false, config, e, svc, prevConfigValidationFunc, ctrl, true
@@ -236,7 +236,7 @@ func Test_Run(t *testing.T) {
 			e.EXPECT().StopExporter().Return(nil)
 
 			svc := mocks.NewMockService(ctrl)
-			svc.EXPECT().ExportVolumeMetrics(gomock.Any()).AnyTimes()
+			svc.EXPECT().ExportQuotaMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterCapacityMetrics(gomock.Any()).AnyTimes()
 			svc.EXPECT().ExportClusterPerformanceMetrics(gomock.Any()).AnyTimes()
 

--- a/internal/service/mocks/metrics_mocks.go
+++ b/internal/service/mocks/metrics_mocks.go
@@ -65,18 +65,32 @@ func (mr *MockMetricsRecorderMockRecorder) RecordClusterPerformanceStatsMetrics(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordClusterPerformanceStatsMetrics", reflect.TypeOf((*MockMetricsRecorder)(nil).RecordClusterPerformanceStatsMetrics), arg0, arg1)
 }
 
-// RecordVolumeSpace mocks base method.
-func (m *MockMetricsRecorder) RecordVolumeSpace(arg0 context.Context, arg1 interface{}, arg2, arg3 int64) error {
+// RecordClusterQuota mocks base method.
+func (m *MockMetricsRecorder) RecordClusterQuota(arg0 context.Context, arg1 interface{}, arg2 *service.ClusterQuotaRecord) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordVolumeSpace", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "RecordClusterQuota", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RecordVolumeSpace indicates an expected call of RecordVolumeSpace.
-func (mr *MockMetricsRecorderMockRecorder) RecordVolumeSpace(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// RecordClusterQuota indicates an expected call of RecordClusterQuota.
+func (mr *MockMetricsRecorderMockRecorder) RecordClusterQuota(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordVolumeSpace", reflect.TypeOf((*MockMetricsRecorder)(nil).RecordVolumeSpace), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordClusterQuota", reflect.TypeOf((*MockMetricsRecorder)(nil).RecordClusterQuota), arg0, arg1, arg2)
+}
+
+// RecordVolumeQuota mocks base method.
+func (m *MockMetricsRecorder) RecordVolumeQuota(arg0 context.Context, arg1 interface{}, arg2 *service.VolumeQuotaMetricsRecord) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecordVolumeQuota", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecordVolumeQuota indicates an expected call of RecordVolumeQuota.
+func (mr *MockMetricsRecorderMockRecorder) RecordVolumeQuota(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordVolumeQuota", reflect.TypeOf((*MockMetricsRecorder)(nil).RecordVolumeQuota), arg0, arg1, arg2)
 }
 
 // MockAsyncMetricCreator is a mock of AsyncMetricCreator interface.

--- a/internal/service/mocks/powerscale_client_mocks.go
+++ b/internal/service/mocks/powerscale_client_mocks.go
@@ -64,18 +64,3 @@ func (mr *MockPowerScaleClientMockRecorder) GetFloatStatistics(arg0, arg1 interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatStatistics", reflect.TypeOf((*MockPowerScaleClient)(nil).GetFloatStatistics), arg0, arg1)
 }
-
-// GetQuotaWithPath mocks base method.
-func (m *MockPowerScaleClient) GetQuotaWithPath(arg0 context.Context, arg1 string) (goisilon.Quota, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetQuotaWithPath", arg0, arg1)
-	ret0, _ := ret[0].(goisilon.Quota)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetQuotaWithPath indicates an expected call of GetQuotaWithPath.
-func (mr *MockPowerScaleClientMockRecorder) GetQuotaWithPath(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQuotaWithPath", reflect.TypeOf((*MockPowerScaleClient)(nil).GetQuotaWithPath), arg0, arg1)
-}

--- a/internal/service/mocks/service_mocks.go
+++ b/internal/service/mocks/service_mocks.go
@@ -58,14 +58,14 @@ func (mr *MockServiceMockRecorder) ExportClusterPerformanceMetrics(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClusterPerformanceMetrics", reflect.TypeOf((*MockService)(nil).ExportClusterPerformanceMetrics), arg0)
 }
 
-// ExportVolumeMetrics mocks base method.
-func (m *MockService) ExportVolumeMetrics(arg0 context.Context) {
+// ExportQuotaMetrics mocks base method.
+func (m *MockService) ExportQuotaMetrics(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ExportVolumeMetrics", arg0)
+	m.ctrl.Call(m, "ExportQuotaMetrics", arg0)
 }
 
-// ExportVolumeMetrics indicates an expected call of ExportVolumeMetrics.
-func (mr *MockServiceMockRecorder) ExportVolumeMetrics(arg0 interface{}) *gomock.Call {
+// ExportQuotaMetrics indicates an expected call of ExportQuotaMetrics.
+func (mr *MockServiceMockRecorder) ExportQuotaMetrics(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportVolumeMetrics", reflect.TypeOf((*MockService)(nil).ExportVolumeMetrics), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportQuotaMetrics", reflect.TypeOf((*MockService)(nil).ExportQuotaMetrics), arg0)
 }

--- a/internal/service/testdata/recordings/client1-quotas.json
+++ b/internal/service/testdata/recordings/client1-quotas.json
@@ -1,0 +1,194 @@
+[
+  {
+    "container": true,
+    "enforced": true,
+    "id": "pwHJAAEAAAAAAAAAAAAAQE0BAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv1",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "user",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  },
+  {
+    "container": true,
+    "enforced": true,
+    "id": "pwHJAAEAAAAAAAAAAAAAQE0BAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv1",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  },
+  {
+    "container": true,
+    "enforced": true,
+    "id": "qAHJAAEAAAAAAAAAAAAAQE4BAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv2/sub1",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  },
+  {
+    "container": true,
+    "enforced": true,
+    "id": "qgHJAAEAAAAAAAAAAAAAQFABAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv2/sub2",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  },
+  {
+    "container": true,
+    "enforced": true,
+    "id": "qQHJAAEAAAAAAAAAAAAAQE8BAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv2",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 32212254722,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  },
+  {
+    "container": true,
+    "enforced": true,
+    "id": "qgHJAAEAAAAAAAAAAAAAQFABAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv2/sub3",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  }
+]

--- a/internal/service/testdata/recordings/client2-quotas.json
+++ b/internal/service/testdata/recordings/client2-quotas.json
@@ -1,0 +1,34 @@
+[
+  {
+    "container": true,
+    "enforced": true,
+    "id": "pwHJAAEAAAAAAAAAAAAAQE0BAAAAAAAA",
+    "include_snapshots": false,
+    "linked": false,
+    "notifications": "default",
+    "path": "/ifs/data/csi/mock-pv3",
+    "persona": null,
+    "ready": true,
+    "thresholds": {
+      "advisory": null,
+      "advisory_exceeded": false,
+      "advisory_last_exceeded": null,
+      "hard": 3221225472,
+      "hard_exceeded": false,
+      "hard_last_exceeded": null,
+      "percent_advisory": null,
+      "percent_soft": null,
+      "soft": null,
+      "soft_exceeded": false,
+      "soft_grace": null,
+      "soft_last_exceeded": null
+    },
+    "thresholds_include_overhead": false,
+    "type": "directory",
+    "usage": {
+      "inodes": 1,
+      "logical": 0,
+      "physical": 2048
+    }
+  }
+]

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -12,7 +12,7 @@ import (
 	"github.com/dell/goisilon"
 )
 
-// VolumeMeta is the details of a volume in an SDC
+// VolumeMeta is the details of a volume
 type VolumeMeta struct {
 	ID                        string
 	PersistentVolumeName      string
@@ -23,7 +23,12 @@ type VolumeMeta struct {
 	Driver                    string
 	IsiPath                   string
 	PersistentVolumeClaimName string
-	NameSpace                 string
+	Namespace                 string
+}
+
+// ClusterMeta is the details of a cluster
+type ClusterMeta struct {
+	ClusterName string
 }
 
 // PowerScaleCluster is a struct that stores all PowerScale connection information.


### PR DESCRIPTION
# Description
- Implement quota metrics
  powerscale_volume_hard_quota_remaining_gigabytes
  powerscale_volume_quota_subscribed_gigabytes
  powerscale_volume_hard_quota_remaining_percentage
  powerscale_volume_quota_subscribed_percentage
  powerscale_directory_total_hard_quota_gigabytes
  powerscale_directory_total_hard_quota_percentage


# GitHub Issues

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/452|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
- [x] Run `make check test`

![image](https://user-images.githubusercontent.com/105041254/180693064-091f2399-4c1b-4bc0-bf3a-31107fa11f01.png)

- [x] Manual inspection of Prometheus
Volume metrics:
![image](https://user-images.githubusercontent.com/105041254/180694670-59c4f397-5a6d-4278-9d6b-e0337af08780.png)
![image](https://user-images.githubusercontent.com/105041254/180694692-6300659c-489d-424e-ac71-316a6c9cd763.png)
![image](https://user-images.githubusercontent.com/105041254/180694595-c5ec64db-2594-42ca-92b8-e43914dbde78.png)
![image](https://user-images.githubusercontent.com/105041254/180694631-961c082f-be39-4f83-9867-3f026ab6d794.png)
Directory metrics:
![image](https://user-images.githubusercontent.com/105041254/180694724-9b1c3a46-538c-438a-8bce-d5fbd9b04711.png)
![image](https://user-images.githubusercontent.com/105041254/180694766-2601689a-970f-403e-868f-f0047154a20a.png)


# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [x] Yes
- [ ] No
