### PR TITLE
Update goisilon to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dell/csm-metrics-powerscale
 go 1.20
 
 require (
-	github.com/dell/goisilon v1.10.0
+	github.com/dell/goisilon v1.11.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/goisilon v1.10.0 h1:3TgECPV/6RzTQsDfhc1rR5rFyKJMNLYopbUJtHpYfyc=
-github.com/dell/goisilon v1.10.0/go.mod h1:fJXHyh1JBcbsmPBquEulaNOFTpj1eEN5vISDf/UY1RQ=
+github.com/dell/goisilon v1.11.0 h1:6kWgCtaQ4kqZegqUEeSuWH63U8iMrX45MmyKuY4PMnw=
+github.com/dell/goisilon v1.11.0/go.mod h1:nvCYNFP77SDd/Jyl63jOfI+rbDsH/4kFpU2G5bXCZ7Y=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
# Description
Update goisilon to v1.11.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/583|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make check test
```
➜ make check test
./scripts/check.sh ./cmd/... ./opentelemetry/... ./internal/...
=== Checking format...
=== Finished  
=== Vetting...
=== Finished  
=== Linting...
=== Finished        
=== Running gosec...
=== Finished
go test -count=1 -cover -race -timeout 30s -short `go list ./... | grep -v mocks`
?       github.com/dell/csm-metrics-powerscale/cmd/metrics-powerscale   [no test files]
ok      github.com/dell/csm-metrics-powerscale/internal/common  0.305s  coverage: 91.5% of statements
?       github.com/dell/csm-metrics-powerscale/opentelemetry/exporters  [no test files]
ok      github.com/dell/csm-metrics-powerscale/internal/entrypoint      1.093s coverage: 90.7% of statements
ok      github.com/dell/csm-metrics-powerscale/internal/k8s     0.101s  coverage: 94.2% of statements
ok      github.com/dell/csm-metrics-powerscale/internal/service 0.099s  coverage: 92.3% of statements
ok      github.com/dell/csm-metrics-powerscale/internal/utils   0.024s  coverage: 100.0% of statements
```

# Manual inspection of the GUI
I have verified that the dashboards show the data properly while generating I/O and storage resources

- [ ] Yes
- [x] No
