### PR TITLE
Add nil check for claimRef to avoid segmentation violation error

### DIFF
--- a/internal/k8s/volume_finder.go
+++ b/internal/k8s/volume_finder.go
@@ -69,6 +69,13 @@ func (f VolumeFinder) GetPersistentVolumes(_ context.Context) ([]VolumeInfo, err
 			f.Logger.Debugf("The PV, %s , is not provisioned by a CSI driver\n", volume.GetName())
 			continue
 		}
+
+		// Check added to skip PV s which do not have any PVC s
+		if volume.Spec.ClaimRef == nil {
+			f.Logger.Debugf("The PV, %s , do not have a claim \n", volume.GetName())
+			continue
+		}
+
 		if contains(f.DriverNames, volume.Spec.CSI.Driver) {
 			capacity := volume.Spec.Capacity[corev1.ResourceStorage]
 			claim := volume.Spec.ClaimRef


### PR DESCRIPTION
# Description
- Added a nil check to skip processing pvs without ClaimRef. This will prevent karavi-metrics-powerscale from crashing when there are unbound pv s in clusters
- Enhanced unit tests to cover the same

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1019|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

Tested the scenario using unit tests and it looks good
![image](https://github.com/dell/csm-metrics-powerscale/assets/82365588/5dddd5d4-80ee-43dc-b795-9a070be97e07)

E2E run :

Test Metrics runs:
![image](https://github.com/dell/csm-metrics-powerscale/assets/82365588/22b6fd9d-d66b-4da9-af10-95c240fed2cb)

Topology tests:
![image](https://github.com/dell/csm-metrics-powerscale/assets/82365588/578e1f08-13fa-4f92-8044-fd3e67c1e7a5)

