### PR TITLE
go version bump-up

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,6 +43,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Run Go Security
         uses: securego/gosec@master
+        with:
+          args: ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Set up Go latest
         uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
         id: go
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csm-metrics-powerscale
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dell/goisilon v1.14.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22