### PR TITLE
Log level value should not be updated with metrics restart

### DIFF
--- a/cmd/metrics-powerscale/main.go
+++ b/cmd/metrics-powerscale/main.go
@@ -55,8 +55,6 @@ func main() {
 func initializeComponents() (*logrus.Logger, *entrypoint.Config, *otlexporters.OtlCollectorExporter, *service.PowerScaleService) {
 	logger := setupLogger()
 
-	loadConfig(logger)
-
 	configFileListener := setupConfigFileListener()
 	leaderElector := &k8s.LeaderElector{API: &k8s.LeaderElector{}}
 	config := setupConfig(logger, leaderElector)
@@ -74,6 +72,7 @@ func initializeComponents() (*logrus.Logger, *entrypoint.Config, *otlexporters.O
 // setupLogger initializes and configures the logger.
 func setupLogger() *logrus.Logger {
 	logger := logrus.New()
+	loadConfig(logger)
 	updateLoggingSettings(logger)
 	return logger
 }


### PR DESCRIPTION
# Description
LOG_LEVEL was getting updated to INFO in configmap if there were any restart to metrics pod.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have inspected the Grafana dashboards to verify the data is displayed properly
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
- E2E passed:
<img width="987" height="275" alt="image" src="https://github.com/user-attachments/assets/431faf3a-bb9d-4a47-b077-b58826c1e1c0" />

- If LOG_LEVEL is set to DEBUG, it is maintained if there are any restarts to metrics pod
<img width="1567" height="201" alt="image" src="https://github.com/user-attachments/assets/8a2ff2b3-0e0c-4055-ad98-c30dd6e28ac8" />


